### PR TITLE
fix font name

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,7 +28,7 @@ flutter:
   fonts:
     - family: WorkSansSemiBold
       fonts:
-        - asset: assets/fonts/Work_Sans/WorkSans-Semibold.ttf
+        - asset: assets/fonts/Work_Sans/WorkSans-SemiBold.ttf
 
     - family: WorkSansBold
       fonts:


### PR DESCRIPTION
Fixing the Error: unable to locate asset entry in pubspec.yaml: "assets/fonts/Work_Sans/WorkSans-Semibold.ttf".